### PR TITLE
Fixed ValidationResult signature

### DIFF
--- a/Definitions/clienttemplates.d.ts
+++ b/Definitions/clienttemplates.d.ts
@@ -480,7 +480,7 @@ declare module SPClientTemplates {
     export interface Group {
         Items: Item[];
     }
-    type RenderCallback = (ctx: RenderContext) => void;
+    type RenderCallback = (ctx: ContextInfo) => void;
 
     export interface RenderContext {
         BaseViewID?: number;

--- a/Definitions/clienttemplates.d.ts
+++ b/Definitions/clienttemplates.d.ts
@@ -700,6 +700,8 @@ declare function CoreRender(template: any, context: any): string;
 declare module SPClientForms {
     module ClientValidation {
         export class ValidationResult {
+			errorMessage: string;
+			validationError: boolean;
             constructor(hasErrors: boolean, errorMsg: string);
         }
 


### PR DESCRIPTION
According to `SPClientForms.ClientValidation.ValidationResult`
![2015-10-15_0037](https://cloud.githubusercontent.com/assets/10658276/10498767/16a81bec-72d5-11e5-87c1-20b5ff971f73.png)
there should be two additional public fields. 
